### PR TITLE
Modernized, exported constants

### DIFF
--- a/CocoaZ/TDTZCommon.h
+++ b/CocoaZ/TDTZCommon.h
@@ -1,6 +1,7 @@
 #import <Foundation/Foundation.h>
 
-typedef enum {
+typedef NS_ENUM(NSUInteger, TDTCompressionFormat) {
   TDTCompressionFormatDeflate,
   TDTCompressionFormatGzip
-} TDTCompressionFormat;
+};
+

--- a/CocoaZ/TDTZCompressor.h
+++ b/CocoaZ/TDTZCompressor.h
@@ -2,6 +2,10 @@
 
 #import "TDTZCommon.h"
 
+// Keys for values included in any compression exception.
+FOUNDATION_EXPORT NSString * const TDTZCompressorException;
+FOUNDATION_EXPORT NSString * const TDTZCompressorExceptionCodeKey;
+
 /**
  This class provides a wrapper over the compression related functions provided by zlib
  */
@@ -39,13 +43,13 @@
 /**
  The designated initializer -- needs compression format and compression level
  */
-- (id)initWithCompressionFormat:(TDTCompressionFormat)compressionFormat level:(int)level;
+- (instancetype)initWithCompressionFormat:(TDTCompressionFormat)compressionFormat level:(int)level;
 
 /**
  Convenience initializer with only compression format.
  It uses Z_DEFAULT_COMPRESSION as compression level
  */
-- (id)initWithCompressionFormat:(TDTCompressionFormat)compressionFormat;
+- (instancetype)initWithCompressionFormat:(TDTCompressionFormat)compressionFormat;
 
 /**
  Sends all input data to the internal zStream and returns any output data proivded

--- a/CocoaZ/TDTZCompressor.m
+++ b/CocoaZ/TDTZCompressor.m
@@ -1,8 +1,8 @@
 #import "TDTZCompressor.h"
 #include <zlib.h>
 
-static NSString *const TDTZCompressorException = @"TDTZCompressorException";
-static NSString *const TDTZExceptionCodeKey = @"TDTZExceptionCodeKey";
+NSString *const TDTZCompressorException = @"TDTZCompressorException";
+NSString *const TDTZCompressorExceptionCodeKey = @"TDTZExceptionCodeKey";
 static const NSInteger OutBufferChunkSizeDefault = 2048;
 static const NSInteger ReadChunkSize = 4096; // in bytes
 
@@ -20,10 +20,10 @@ static const NSInteger ReadChunkSize = 4096; // in bytes
 + (NSException *)exceptionWithCode:(int)code msg:(const char *)msg {
   return [NSException exceptionWithName:TDTZCompressorException
                                  reason:@(msg)
-                               userInfo:@{TDTZExceptionCodeKey: @(code)}];
+                               userInfo:@{TDTZCompressorExceptionCodeKey: @(code)}];
 }
 
-- (id)initWithCompressionFormat:(TDTCompressionFormat)compressionFormat level:(int)level {
+- (instancetype)initWithCompressionFormat:(TDTCompressionFormat)compressionFormat level:(int)level {
   self = [super init];
   if (self) {
     _isZStreamInitialized = NO;
@@ -40,7 +40,7 @@ static const NSInteger ReadChunkSize = 4096; // in bytes
   return self;
 }
 
-- (id)initWithCompressionFormat:(TDTCompressionFormat)compressionFormat {
+- (instancetype)initWithCompressionFormat:(TDTCompressionFormat)compressionFormat {
   return [self initWithCompressionFormat:compressionFormat level:Z_DEFAULT_COMPRESSION];
 }
 

--- a/CocoaZ/TDTZDecompressor.h
+++ b/CocoaZ/TDTZDecompressor.h
@@ -2,6 +2,10 @@
 
 #import "TDTZCommon.h"
 
+// Keys for values included in any decompression exception.
+FOUNDATION_EXPORT NSString * const TDTZDecompressorException;
+FOUNDATION_EXPORT NSString * const TDTZDecompressorExceptionCodeKey;
+
 /**
  This class provides a wrapper over the decompression related functions provided by zlib
  */
@@ -31,7 +35,7 @@
 /**
  Initialize with the given decompression format.
  */
-- (id)initWithCompressionFormat:(TDTCompressionFormat)compressionFormat;
+- (instancetype)initWithCompressionFormat:(TDTCompressionFormat)compressionFormat;
 
 /**
  Sends all input data to the internal zStream and returns any output data proivded

--- a/CocoaZ/TDTZDecompressor.m
+++ b/CocoaZ/TDTZDecompressor.m
@@ -1,8 +1,8 @@
 #import "TDTZDecompressor.h"
 #include <zlib.h>
 
-static NSString *const TDTZDecompressorException = @"TDTZDecompressorException";
-static NSString *const TDTZExceptionCodeKey = @"TDTZExceptionCodeKey";
+NSString *const TDTZDecompressorException = @"TDTZDecompressorException";
+NSString *const TDTZDecompressorExceptionCodeKey = @"TDTZExceptionCodeKey";
 static const NSInteger OutBufferChunkSizeDefault = 2048;
 static const NSInteger ReadChunkSize = 4096; // in bytes
 
@@ -20,10 +20,10 @@ static const NSInteger ReadChunkSize = 4096; // in bytes
 + (NSException *)exceptionWithCode:(int)code msg:(const char *)msg {
   return [NSException exceptionWithName:TDTZDecompressorException
                                  reason:@(msg)
-                               userInfo:@{TDTZExceptionCodeKey: @(code)}];
+                               userInfo:@{TDTZDecompressorExceptionCodeKey: @(code)}];
 }
 
-- (id)initWithCompressionFormat:(TDTCompressionFormat)compressionFormat {
+- (instancetype)initWithCompressionFormat:(TDTCompressionFormat)compressionFormat {
   self = [super init];
   if (self) {
     _isZStreamInitialized = NO;


### PR DESCRIPTION
Some minor tweaks for a more modern library: `instancetype` for init methods, plus `NS_ENUM` for the compression format enum.

I've also publicly exported the keys used to create an exception when (de)compression fails. Without those keys, I cannot properly parse any exceptions raised by CocoaZ.

Thanks again for a neat library!
