### PR TITLE
Do not fail on Z_BUF_ERROR

### DIFF
--- a/CocoaZ/TDTZCompressor.m
+++ b/CocoaZ/TDTZCompressor.m
@@ -75,7 +75,7 @@ static const NSInteger ReadChunkSize = 4096; // in bytes
       zStream->avail_out = outBufferChunkSize;
     }
     int result = deflate(zStream, flush);
-    if (result != Z_OK && result != Z_STREAM_END) {
+    if (result != Z_OK && result != Z_STREAM_END && result != Z_BUF_ERROR) {
       @throw [[self class] exceptionWithCode : result msg : zStream->msg];
     }
     bytesCompressed += (outBufferChunkSize - zStream->avail_out);

--- a/Tests/CocoaZTests.xcodeproj/project.pbxproj
+++ b/Tests/CocoaZTests.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		54BCAD9D19B6D3B700164F72 /* TDTRandomInput.m in Sources */ = {isa = PBXBuildFile; fileRef = 54BCAD9C19B6D3B700164F72 /* TDTRandomInput.m */; };
+		697816E31CCF8071005071CE /* TDTCocoaZBufferErrorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 697816E21CCF8071005071CE /* TDTCocoaZBufferErrorTests.m */; };
 		ADBAFD6018AB65CE0020865B /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ADBAFD3918AB655F0020865B /* XCTest.framework */; };
 		ADBAFD6618AB65CE0020865B /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = ADBAFD6418AB65CE0020865B /* InfoPlist.strings */; };
 		ADBAFD7418AB750B0020865B /* TDTZCompressorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = ADBAFD7318AB750B0020865B /* TDTZCompressorTests.m */; };
@@ -16,10 +17,10 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		3C84F34490904BC5B5CE2777 /* Pods-osx.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-osx.xcconfig"; path = "Pods/Pods-osx.xcconfig"; sourceTree = "<group>"; };
 		3D4781BAEB724C1E8712380D /* libPods-osx.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-osx.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		54BCAD9B19B6D3B700164F72 /* TDTRandomInput.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TDTRandomInput.h; sourceTree = "<group>"; };
 		54BCAD9C19B6D3B700164F72 /* TDTRandomInput.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TDTRandomInput.m; sourceTree = "<group>"; };
+		697816E21CCF8071005071CE /* TDTCocoaZBufferErrorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TDTCocoaZBufferErrorTests.m; sourceTree = "<group>"; };
 		ADBAFD2618AB651C0020865B /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		ADBAFD3918AB655F0020865B /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		ADBAFD5F18AB65CE0020865B /* OSXTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OSXTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -77,6 +78,7 @@
 				ADBAFD6218AB65CE0020865B /* Supporting Files */,
 				ADBAFD7318AB750B0020865B /* TDTZCompressorTests.m */,
 				ADBAFD7618AB751B0020865B /* TDTZDecompressorTests.m */,
+				697816E21CCF8071005071CE /* TDTCocoaZBufferErrorTests.m */,
 				54BCAD9B19B6D3B700164F72 /* TDTRandomInput.h */,
 				54BCAD9C19B6D3B700164F72 /* TDTRandomInput.m */,
 			);
@@ -191,6 +193,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				697816E31CCF8071005071CE /* TDTCocoaZBufferErrorTests.m in Sources */,
 				54BCAD9D19B6D3B700164F72 /* TDTRandomInput.m in Sources */,
 				ADBAFD7418AB750B0020865B /* TDTZCompressorTests.m in Sources */,
 				ADBAFD7718AB751B0020865B /* TDTZDecompressorTests.m in Sources */,

--- a/Tests/OSXTests/TDTCocoaZBufferErrorTests.m
+++ b/Tests/OSXTests/TDTCocoaZBufferErrorTests.m
@@ -1,0 +1,79 @@
+#import <XCTest/XCTest.h>
+#import <CocoaZ/TDTZDecompressor.h>
+#import <CocoaZ/TDTZCompressor.h>
+#import "TDTRandomInput.h"
+
+/**
+ These tests were to try to and reproduce a Z_BUF_ERROR by
+ setting up the scenarios outlined in the FAQ [1].
+
+   5. deflate() or inflate() returns Z_BUF_ERROR.
+
+   "Before making the call, make sure that avail_in and avail_out are not zero."
+
+   "When setting the parameter flush equal to Z_FINISH,
+    also make sure that avail_out is big enough to allow processing
+    all pending input."
+
+ Only testCompressFlushWithoutData triggered the Z_BUF_ERROR. The
+ rest are being retained for future reference.
+
+ [1]: http://www.zlib.net/zlib_faq.html#faq05
+ */
+@interface TDTCocoaZBufferErrorTests : XCTestCase
+
+@end
+
+@implementation TDTCocoaZBufferErrorTests
+
+- (void)testDecompressNoInput {
+  TDTZDecompressor *decompressor = [[TDTZDecompressor alloc] initWithCompressionFormat:TDTCompressionFormatDeflate];
+
+  XCTAssertNotNil([decompressor decompressData:nil]);
+}
+
+- (void)testDecompressNoInputFinish {
+  TDTZDecompressor *decompressor = [[TDTZDecompressor alloc] initWithCompressionFormat:TDTCompressionFormatDeflate];
+
+  XCTAssertNotNil([decompressor finishData:nil]);
+}
+
+- (void)testDecompressFlushWithoutData {
+  TDTZDecompressor *decompressor = [[TDTZDecompressor alloc] initWithCompressionFormat:TDTCompressionFormatDeflate];
+
+  XCTAssertNotNil([decompressor decompressData:[self someCompressedDeflateData]]);
+  XCTAssertNotNil([decompressor flushData:nil]);
+  XCTAssertNotNil([decompressor flushData:nil]);
+}
+
+- (NSData *)someCompressedDeflateData {
+  NSData *data = [@"test" dataUsingEncoding:NSUTF8StringEncoding];
+  TDTZCompressor *compressor = [[TDTZCompressor alloc] initWithCompressionFormat:TDTCompressionFormatDeflate];
+  return [compressor finishData:data];
+}
+
+- (void)testCompressBufferResizingOnFinishWithSmallBuffer {
+  TDTZCompressor *compressor = [[TDTZCompressor alloc] initWithCompressionFormat:TDTCompressionFormatDeflate];
+  compressor.outBufferChunkSize = 32;
+
+  XCTAssertNotNil([compressor finishData:randomLargeData()]);
+}
+
+- (void)testCompressBufferResizingOnFinishWithSmallBufferAndPendingOutput {
+  TDTZCompressor *compressor = [[TDTZCompressor alloc] initWithCompressionFormat:TDTCompressionFormatDeflate];
+  compressor.outBufferChunkSize = 32;
+
+  XCTAssertNotNil([compressor compressData:randomLargeData()]);
+  XCTAssertNotNil([compressor finishData:nil]);
+}
+
+- (void)testCompressFlushWithoutData {
+  TDTZCompressor *compressor = [[TDTZCompressor alloc] initWithCompressionFormat:TDTCompressionFormatDeflate];
+
+  NSData *data = [@"test" dataUsingEncoding:NSUTF8StringEncoding];
+  XCTAssertNotNil([compressor compressData:data]);
+  XCTAssertNotNil([compressor flushData:nil]);
+  XCTAssertNotNil([compressor flushData:nil]);
+}
+
+@end


### PR DESCRIPTION
The zlib documentation seems to hint that Z_BUF_ERROR is not
necessarily a result of incorrect parameters being passed to zlib, and
can in fact occur in normal use.

* zlib.h:

    Note that Z_BUF_ERROR is not fatal, and deflate() can be called
    again with more input and more output space to continue
    compressing.

* http://www.zlib.net/zlib_faq.html#faq05
* http://zlib.net/zlib_how.html

This change was motivated by a crash on a "buffer error"
TDTZCompressorException in one of our apps.  The crash is not
reproducible, and neither do we have the exact data or state of CocoaZ
at the time the crash occurred.  The caller code that uses CocoaZ has
been reasonably well tested, and does not have any "obvious" incorrect
parameter passing issues.

<img width="521" alt="screen shot 2016-04-21 at 4 34 33 pm" src="https://cloud.githubusercontent.com/assets/1145108/14707146/a09d6118-07e0-11e6-944a-8474c1c9f5b7.png">
