### PR TITLE
Use HTTPS URL in Podspec

### DIFF
--- a/CocoaZ.podspec
+++ b/CocoaZ.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.author   = 'Talk.to'
   s.license  = 'BSD'
   s.source   = {
-    :git => 'git@github.com:talk-to/CocoaZ.git',
+    :git => 'https://github.com/talk-to/CocoaZ.git',
     :tag => "#{s.version}"
   }
   s.requires_arc = true


### PR DESCRIPTION
CocoaPods was not allowing me to push to trunk, even after supressing
warnings. I have not tested if this fixes the issue because I do not
know if a dry run is possible.

    $ pod trunk push CocoaZ.podspec
    Updating spec repo `master`
    Validating podspec
     -> CocoaZ (1.4.1)
        - WARN  | source: Git SSH URLs will NOT work for people behind firewalls configured to only allow HTTP, therefore HTTPS is preferred.

    [!] The podspec does not validate.

    $ pod trunk push CocoaZ.podspec  --allow-warnings
    Updating spec repo `master`
    Validating podspec
     -> CocoaZ (1.4.1)
        - WARN  | source: Git SSH URLs will NOT work for people behind firewalls configured to only allow HTTP, therefore HTTPS is preferred.

    [!] Source code for your Pod was not accessible to CocoaPods Trunk. Is it a private repo or behind a username/password on http?

    $ pod --version
    0.39.0